### PR TITLE
Fix for issue #52 - Close entity when page is to big

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
+++ b/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
@@ -274,6 +274,8 @@ public class PageFetcher extends Configurable {
             }
           }
           if (size > config.getMaxDownloadSize()) {
+            //fix issue #52 - consume entity
+            response.close();
             throw new PageBiggerThanMaxSizeException(size);
           }
         }


### PR DESCRIPTION
As described in the issue mentioned above this should fix the problem of the freezing crawler.